### PR TITLE
Stop calling back into C to raise exceptions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include go.mod
 include go.sum
 include starlark.c
 include starlark.go
+include starlark.h

--- a/src/pystarlark/__init__.py
+++ b/src/pystarlark/__init__.py
@@ -11,9 +11,6 @@ __version__ = "0.0.2"
 
 
 class Starlark(StarlarkGo):
-    def eval(self, statement: str, _raw: bool = False) -> Any:
+    def eval(self, statement: str) -> Any:
         response = super().eval(statement)
-        if _raw:
-            return response
-        value = json.loads(response)["value"]
-        return literal_eval(value)
+        return literal_eval(response)

--- a/starlark.h
+++ b/starlark.h
@@ -1,0 +1,32 @@
+typedef struct StarlarkErrorArgs {
+  char *error;
+  char *error_type;
+} StarlarkErrorArgs;
+
+typedef struct SyntaxErrorArgs {
+  char *error;
+  char *error_type;
+  char *msg;
+  char *filename;
+  unsigned int line;
+  unsigned int column;
+} SyntaxErrorArgs;
+
+typedef struct EvalErrorArgs {
+  char *error;
+  char *error_type;
+  char *backtrace;
+} EvalErrorArgs;
+
+typedef enum StarlarkErrorType {
+  STARLARK_NO_ERROR = 0,
+  STARLARK_GENERAL_ERROR = 1,
+  STARLARK_SYNTAX_ERROR = 2,
+  STARLARK_EVAL_ERROR = 3
+} StarlarkErrorType;
+
+typedef struct StarlarkReturn {
+  char *value;
+  StarlarkErrorType error_type;
+  void *error;
+} StarlarkReturn;


### PR DESCRIPTION
Instead, Eval and ExecFile now return a StarlarkReturn struct, which exception information is parsed out of.

I've also dropped the undocumented `_raw` parameter and the additional JSON serialization; if you want to verify the type of the return value you can just use `instanceof` and friends, and dropping the intermediate JSON encode/decode should spare some CPU cycles.