### PR TITLE
More devcontainer tweaks

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,6 +48,7 @@ RUN go install github.com/fatih/gomodifytags@latest
 RUN go install github.com/haya14busa/goplay/cmd/goplay@latest
 RUN go install github.com/cweill/gotests/...@latest
 RUN go install honnef.co/go/tools/cmd/staticcheck@latest
+RUN go install mvdan.cc/gofumpt@latest
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
 
 
@@ -57,6 +58,6 @@ ARG USERNAME
 
 COPY --from=go_tools /home/${USERNAME}/go/bin/ /home/${USERNAME}/go/bin
 
-RUN python3.10 -m pip install --user black isort tox
+RUN python3.10 -m pip install --user black isort pytest tox
 
 ENV PATH=/home/${USERNAME}/go/bin:/home/${USERNAME}/.local/bin:$PATH

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,11 @@
     "[c]": {
       "editor.defaultFormatter": "ms-vscode.cpptools"
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "go.lintTool": "golangci-lint",
+    "gopls": {
+      "formatting.gofumpt": true
+    },
   },
   "extensions": [
     "bierner.github-markdown-preview",

--- a/development.txt
+++ b/development.txt
@@ -1,6 +1,3 @@
 setuptools-golang==2.7.0
 wheel==0.37.1
-black==22.3.0
-isort==5.10.1
-twine==4.0.0
 pytest==7.1.1


### PR DESCRIPTION
- Install pytest
- Install gofumpt and use it
- Strip development.txt down to only what tests need