### PR TITLE
Test mutiple calls to exec / handle resolve.Error

### DIFF
--- a/src/pystarlark/__init__.py
+++ b/src/pystarlark/__init__.py
@@ -2,9 +2,9 @@ from ast import literal_eval
 from typing import Any, Optional
 
 from pystarlark._lib import StarlarkGo
-from pystarlark.errors import EvalError, StarlarkError, SyntaxError
+from pystarlark.errors import EvalError, ResolveError, StarlarkError, SyntaxError
 
-__all__ = ["Starlark", "StarlarkError", "EvalError", "SyntaxError"]
+__all__ = ["Starlark", "StarlarkError", "EvalError", "ResolveError", "SyntaxError"]
 __version__ = "0.0.2"
 
 

--- a/src/pystarlark/errors.py
+++ b/src/pystarlark/errors.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Tuple
 
 __all__ = ["StarlarkError", "SyntaxError", "EvalError"]
 
@@ -34,3 +34,18 @@ class EvalError(StarlarkError):
     def __init__(self, error: str, error_type: str, backtrace: str):
         super().__init__(error, error_type, backtrace)
         self.backtrace = backtrace
+
+
+class ResolveErrorItem:
+    def __init__(self, msg: str, line: int, column: int):
+        self.msg = msg
+        self.line = line
+        self.column = column
+
+
+class ResolveError(StarlarkError):
+    def __init__(
+        self, error: str, error_type: str, errors: Tuple[ResolveErrorItem, ...]
+    ):
+        super().__init__(error, error_type)
+        self.errors = list(errors)

--- a/starlark.h
+++ b/starlark.h
@@ -24,6 +24,12 @@ PyObject *CgoSyntaxErrorArgs(const char *error_msg, const char *error_type,
 PyObject *CgoEvalErrorArgs(const char *error_msg, const char *error_type,
                            const char *backtrace);
 
+PyObject *CgoResolveErrorItem(const char *msg, const unsigned int line,
+                              const unsigned int column);
+
+PyObject *CgoResolveErrorArgs(const char *error_msg, const char *error_type,
+                              PyObject *errors);
+
 void CgoPyDecRef(PyObject *obj);
 
 PyObject *CgoPyBuildOneValue(const char *fmt, const void *src);
@@ -37,5 +43,7 @@ int GgoParseExecArgs(PyObject *args, PyObject *kwargs, char **defs,
                      char **filename);
 
 PyTypeObject *CgoPyType(PyObject *obj);
+
+void CgoPyTuple_SET_ITEM(PyObject *tuple, Py_ssize_t pos, PyObject *item);
 
 #endif /* PYTHON_STARLARK_GO_H */

--- a/tests/test_multi_exec.py
+++ b/tests/test_multi_exec.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pystarlark import ResolveError, Starlark
+
+ADD_ONE = """
+def add_one(x):
+    return x + 1
+"""
+
+ADD_TWO = """
+def add_two(x):
+    return add_one(add_one(x))
+"""
+
+
+def test_multi_exec():
+    s = Starlark()
+
+    s.exec(ADD_ONE)
+
+    assert s.eval("add_one(1)") == 2
+
+    with pytest.raises(ResolveError):
+        s.eval("add_two(1)")
+
+    s.exec(ADD_TWO)
+
+    assert s.eval("add_two(1)") == 3

--- a/tests/test_resolveerror.py
+++ b/tests/test_resolveerror.py
@@ -1,0 +1,61 @@
+from pystarlark import ResolveError, Starlark
+
+
+def test_eval_resolveerror():
+    s = Starlark()
+    raised = False
+
+    try:
+        s.eval("add_one(1)")
+    except ResolveError as e:
+        assert isinstance(e.errors, list)
+        assert len(e.errors) == 1
+        assert e.errors[0].line == 1
+        assert e.errors[0].column == 1
+        assert e.errors[0].msg == "undefined: add_one"
+        raised = True
+
+    try:
+        s.eval("from_bad(True) + to_worse(True)")
+    except ResolveError as e:
+        assert isinstance(e.errors, list)
+        assert len(e.errors) == 2
+        assert e.errors[0].line == 1
+        assert e.errors[0].column == 1
+        assert e.errors[0].msg == "undefined: from_bad"
+        assert e.errors[1].line == 1
+        assert e.errors[1].column == 18
+        assert e.errors[1].msg == "undefined: to_worse"
+        raised = True
+
+    assert raised
+
+
+def test_exec_resolveerror():
+    s = Starlark()
+    raised = False
+
+    try:
+        s.exec("add_one(1)")
+    except ResolveError as e:
+        assert isinstance(e.errors, list)
+        assert len(e.errors) == 1
+        assert e.errors[0].line == 1
+        assert e.errors[0].column == 1
+        assert e.errors[0].msg == "undefined: add_one"
+        raised = True
+
+    try:
+        s.exec("from_bad(True) + to_worse(True)")
+    except ResolveError as e:
+        assert isinstance(e.errors, list)
+        assert len(e.errors) == 2
+        assert e.errors[0].line == 1
+        assert e.errors[0].column == 1
+        assert e.errors[0].msg == "undefined: from_bad"
+        assert e.errors[1].line == 1
+        assert e.errors[1].column == 18
+        assert e.errors[1].msg == "undefined: to_worse"
+        raised = True
+
+    assert raised


### PR DESCRIPTION
In https://github.com/caketop/pystarlark/pull/26 another change snuck in to retain the globals across multiple calls to exec, so that it could be used to define multiple things. While writing a test for this behavior, I discovered that it is possible for starlark-go's Eval to return a resolve.ErrorList, in addition to a starlark.EvalError or a syntax.Error, so I had to add handling for that as well.