### PR TITLE
Give up the GIL during Starlark execution

### DIFF
--- a/starlark.c
+++ b/starlark.c
@@ -128,11 +128,6 @@ PyObject *CgoPyNone() {
   Py_RETURN_NONE;
 }
 
-PyTypeObject *CgoPyType(PyObject *obj) {
-  /* Necessary because Cgo can't do macros */
-  return Py_TYPE(obj);
-}
-
 /* Helper to fetch exception classes */
 static PyObject *get_exception_class(PyObject *errors, const char *name) {
   PyObject *retval = PyObject_GetAttrString(errors, name);

--- a/starlark.go
+++ b/starlark.go
@@ -75,7 +75,6 @@ func raisePythonException(err error) {
 			defer C.free(unsafe.Pointer(msg))
 
 			C.PyTuple_SetItem(items, C.Py_ssize_t(i), C.CgoResolveErrorItem(msg, C.uint(err.Pos.Line), C.uint(err.Pos.Col)))
-			// C.CgoPyTuple_SET_ITEM(items, C.Py_ssize_t(i), C.CgoResolveErrorItem(msg, C.uint(err.Pos.Line), C.uint(err.Pos.Col)))
 		}
 
 		exc_args = C.CgoResolveErrorArgs(error_msg, error_type, items)

--- a/starlark.go
+++ b/starlark.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"math/rand"
 	"reflect"
+	"sync"
 	"unsafe"
 
 	"go.starlark.net/resolve"
@@ -28,6 +29,7 @@ import (
 var (
 	THREADS = map[uint64]*starlark.Thread{}
 	GLOBALS = map[uint64]starlark.StringDict{}
+	MUTEXES = map[uint64]*sync.Mutex{}
 )
 
 func raisePythonException(err error) {
@@ -66,13 +68,14 @@ func raisePythonException(err error) {
 		exc_type = C.EvalError
 	case errors.As(err, &resolveErr):
 		items := C.PyTuple_New(C.Py_ssize_t(len(resolveErr)))
-		defer C.CgoPyDecRef(items)
+		defer C.Py_DecRef(items)
 
 		for i, err := range resolveErr {
 			msg := C.CString(err.Msg)
 			defer C.free(unsafe.Pointer(msg))
 
-			C.CgoPyTuple_SET_ITEM(items, C.Py_ssize_t(i), C.CgoResolveErrorItem(msg, C.uint(err.Pos.Line), C.uint(err.Pos.Col)))
+			C.PyTuple_SetItem(items, C.Py_ssize_t(i), C.CgoResolveErrorItem(msg, C.uint(err.Pos.Line), C.uint(err.Pos.Col)))
+			// C.CgoPyTuple_SET_ITEM(items, C.Py_ssize_t(i), C.CgoResolveErrorItem(msg, C.uint(err.Pos.Line), C.uint(err.Pos.Col)))
 		}
 
 		exc_args = C.CgoResolveErrorArgs(error_msg, error_type, items)
@@ -83,7 +86,7 @@ func raisePythonException(err error) {
 	}
 
 	C.PyErr_SetObject(exc_type, exc_args)
-	C.CgoPyDecRef(exc_args)
+	C.Py_DecRef(exc_args)
 }
 
 //export StarlarkGo_new
@@ -95,8 +98,10 @@ func StarlarkGo_new(pytype *C.PyTypeObject, args *C.PyObject, kwargs *C.PyObject
 
 	threadId := rand.Uint64()
 	thread := &starlark.Thread{}
+
 	THREADS[threadId] = thread
 	GLOBALS[threadId] = starlark.StringDict{}
+	MUTEXES[threadId] = &sync.Mutex{}
 
 	self.starlark_thread = C.ulong(threadId)
 	return self
@@ -105,8 +110,14 @@ func StarlarkGo_new(pytype *C.PyTypeObject, args *C.PyObject, kwargs *C.PyObject
 //export StarlarkGo_dealloc
 func StarlarkGo_dealloc(self *C.StarlarkGo) {
 	threadId := uint64(self.starlark_thread)
+	mutex := MUTEXES[threadId]
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	delete(THREADS, threadId)
 	delete(GLOBALS, threadId)
+	delete(MUTEXES, threadId)
 
 	C.CgoStarlarkGoDealloc(self)
 }
@@ -131,10 +142,17 @@ func StarlarkGo_eval(self *C.StarlarkGo, args *C.PyObject, kwargs *C.PyObject) *
 	}
 
 	threadId := uint64(self.starlark_thread)
+	mutex := MUTEXES[threadId]
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	thread := THREADS[threadId]
 	globals := GLOBALS[threadId]
-
+	pyThread := C.PyEval_SaveThread()
 	result, err := starlark.Eval(thread, goFilename, goExpr, globals)
+	C.PyEval_RestoreThread(pyThread)
+
 	if err != nil {
 		raisePythonException(err)
 		return nil
@@ -165,9 +183,16 @@ func StarlarkGo_exec(self *C.StarlarkGo, args *C.PyObject, kwargs *C.PyObject) *
 	}
 
 	threadId := uint64(self.starlark_thread)
-	thread := THREADS[threadId]
+	mutex := MUTEXES[threadId]
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	thread := THREADS[threadId]
+	pyThread := C.PyEval_SaveThread()
 	globals, err := starlark.ExecFile(thread, goFilename, goDefs, GLOBALS[threadId])
+	C.PyEval_RestoreThread(pyThread)
+
 	if err != nil {
 		raisePythonException(err)
 		return nil

--- a/starlark.h
+++ b/starlark.h
@@ -29,9 +29,6 @@ PyObject *CgoResolveErrorItem(const char *msg, const unsigned int line,
 
 PyObject *CgoResolveErrorArgs(const char *error_msg, const char *error_type,
                               PyObject *errors);
-
-void CgoPyDecRef(PyObject *obj);
-
 PyObject *CgoPyBuildOneValue(const char *fmt, const void *src);
 
 PyObject *CgoPyNone();
@@ -43,7 +40,5 @@ int GgoParseExecArgs(PyObject *args, PyObject *kwargs, char **defs,
                      char **filename);
 
 PyTypeObject *CgoPyType(PyObject *obj);
-
-void CgoPyTuple_SET_ITEM(PyObject *tuple, Py_ssize_t pos, PyObject *item);
 
 #endif /* PYTHON_STARLARK_GO_H */

--- a/starlark.h
+++ b/starlark.h
@@ -39,6 +39,4 @@ int CgoParseEvalArgs(PyObject *args, PyObject *kwargs, char **expr,
 int GgoParseExecArgs(PyObject *args, PyObject *kwargs, char **defs,
                      char **filename);
 
-PyTypeObject *CgoPyType(PyObject *obj);
-
 #endif /* PYTHON_STARLARK_GO_H */


### PR DESCRIPTION
I had some weird ideas about the GIL that I cleared up today. This
removes an unneccesary GIL lock in one spot, and changes `exec` and
`eval` to give up the GIL while they're busy executing Starlark code.
A mutex is added per Starlark thread to prevent multiple Python threads
from trying to access the same Starlark thread at once.

Also removed a couple unneccesary Cgo wrappers where I could use the
Python API directly instead.