### PR TITLE
Convert starlark.Value in Go using Python C API

### DIFF
--- a/src/pystarlark/__init__.py
+++ b/src/pystarlark/__init__.py
@@ -1,31 +1,19 @@
-from ast import literal_eval
-from typing import Any, Optional
+from pystarlark._lib import StarlarkGo as Starlark
+from pystarlark.errors import (
+    ConversionError,
+    EvalError,
+    ResolveError,
+    StarlarkError,
+    SyntaxError,
+)
 
-from pystarlark._lib import StarlarkGo
-from pystarlark.errors import EvalError, ResolveError, StarlarkError, SyntaxError
+__all__ = [
+    "Starlark",
+    "StarlarkError",
+    "ConversionError",
+    "EvalError",
+    "ResolveError",
+    "SyntaxError",
+]
 
-__all__ = ["Starlark", "StarlarkError", "EvalError", "ResolveError", "SyntaxError"]
 __version__ = "0.0.2"
-
-
-class Starlark(StarlarkGo):
-    def eval(
-        self,
-        expr: str,
-        filename: Optional[str] = None,
-        parse: Optional[bool] = None,
-    ) -> Any:
-        kwargs = {}
-        should_parse = True
-
-        if filename is not None:
-            kwargs["filename"] = filename
-        if parse is not None:
-            kwargs["parse"] = parse
-            should_parse = bool(parse)
-
-        response = super().eval(expr, **kwargs)
-        if should_parse:
-            response = literal_eval(response)
-
-        return response

--- a/src/pystarlark/errors.py
+++ b/src/pystarlark/errors.py
@@ -1,13 +1,13 @@
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 __all__ = ["StarlarkError", "SyntaxError", "EvalError"]
 
 
 class StarlarkError(Exception):
-    def __init__(self, error: str, error_type: str, *extra_args: Any):
+    def __init__(self, error: str, error_type: Optional[str] = None, *extra_args: Any):
         super().__init__(error, error_type, *extra_args)
         self.error = error
-        self.error_type = error_type
+        self.error_type = self.__class__.__name__ if error_type is None else error_type
 
     def __str__(self) -> str:
         return self.error
@@ -47,5 +47,9 @@ class ResolveError(StarlarkError):
     def __init__(
         self, error: str, error_type: str, errors: Tuple[ResolveErrorItem, ...]
     ):
-        super().__init__(error, error_type)
+        super().__init__(error, error_type, errors)
         self.errors = list(errors)
+
+
+class ConversionError(StarlarkError):
+    pass

--- a/starlark.c
+++ b/starlark.c
@@ -6,8 +6,10 @@ PyObject *SyntaxError;
 PyObject *EvalError;
 PyObject *ResolveError;
 PyObject *ResolveErrorItem;
+PyObject *ConversionError;
 
 /* For use with CgoPyBuildOneValue */
+const char *buildBool = "p";
 const char *buildStr = "s";
 const char *buildUint = "I";
 
@@ -128,6 +130,14 @@ PyObject *CgoPyNone() {
   Py_RETURN_NONE;
 }
 
+PyObject *CgoPyNewRef(PyObject *obj) {
+  /* Necessary because Cgo can't do macros and Py_NewRef is part of
+   * Python's "stable API" but only since 3.10
+   */
+  Py_INCREF(obj);
+  return obj;
+}
+
 /* Helper to fetch exception classes */
 static PyObject *get_exception_class(PyObject *errors, const char *name) {
   PyObject *retval = PyObject_GetAttrString(errors, name);
@@ -163,6 +173,10 @@ PyMODINIT_FUNC PyInit__lib(void) {
 
   ResolveErrorItem = get_exception_class(errors, "ResolveErrorItem");
   if (ResolveErrorItem == NULL)
+    return NULL;
+
+  ConversionError = get_exception_class(errors, "ConversionError");
+  if (ConversionError == NULL)
     return NULL;
 
   PyObject *m;

--- a/starlark.go
+++ b/starlark.go
@@ -8,7 +8,9 @@ extern PyObject *StarlarkError;
 extern PyObject *SyntaxError;
 extern PyObject *EvalError;
 extern PyObject *ResolveError;
+extern PyObject *ConversionError;
 
+extern const char *buildBool;
 extern const char *buildStr;
 extern const char *buildUint;
 */
@@ -16,6 +18,7 @@ import "C"
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -31,6 +34,10 @@ var (
 	GLOBALS = map[uint64]starlark.StringDict{}
 	MUTEXES = map[uint64]*sync.Mutex{}
 )
+
+func init() {
+	resolve.AllowSet = true
+}
 
 func raisePythonException(err error) {
 	var (
@@ -86,6 +93,162 @@ func raisePythonException(err error) {
 
 	C.PyErr_SetObject(exc_type, exc_args)
 	C.Py_DecRef(exc_args)
+}
+
+func starlarkIntToPython(x starlark.Int) *C.PyObject {
+	/* Try to do it quickly */
+	xint, ok := x.Int64()
+	if ok {
+		return C.PyLong_FromLongLong(C.longlong(xint))
+	}
+
+	/* Fall back to converting from string */
+	cstr := C.CString(x.String())
+	defer C.free(unsafe.Pointer(cstr))
+	return C.PyLong_FromString(cstr, nil, 10)
+}
+
+func starlarkStringToPython(x starlark.String) *C.PyObject {
+	cstr := C.CString(string(x))
+	defer C.free(unsafe.Pointer(cstr))
+	return C.CgoPyBuildOneValue(C.buildStr, unsafe.Pointer(cstr))
+}
+
+func starlarkDictToPython(x starlark.IterableMapping) *C.PyObject {
+	items := x.Items()
+	dict := C.PyDict_New()
+
+	for _, item := range items {
+		key := starlarkToPython(item[0])
+		defer C.Py_DecRef(key)
+
+		if key == nil {
+			C.Py_DecRef(dict)
+			return nil
+		}
+
+		value := starlarkToPython((item[1]))
+		defer C.Py_DecRef(value)
+
+		if value == nil {
+			C.Py_DecRef(dict)
+			return nil
+		}
+
+		// This does not steal references
+		C.PyDict_SetItem(dict, key, value)
+	}
+
+	return dict
+}
+
+func starlarkTupleToPython(x starlark.Tuple) *C.PyObject {
+	tuple := C.PyTuple_New(C.Py_ssize_t(x.Len()))
+	iter := x.Iterate()
+	defer iter.Done()
+
+	var elem starlark.Value
+	for i := 0; iter.Next(&elem); i++ {
+		value := starlarkToPython(elem)
+
+		if value == nil {
+			C.Py_DecRef(value)
+			C.Py_DecRef(tuple)
+			return nil
+		}
+
+		// This "steals" the ref to value so we don't need to DecRef
+		C.PyTuple_SetItem(tuple, C.Py_ssize_t(i), value)
+	}
+
+	return tuple
+}
+
+func starlarkListToPython(x starlark.Iterable) *C.PyObject {
+	list := C.PyList_New(0)
+	iter := x.Iterate()
+	defer iter.Done()
+
+	var elem starlark.Value
+	for i := 0; iter.Next(&elem); i++ {
+		value := starlarkToPython(elem)
+
+		if value == nil {
+			C.Py_DecRef(value)
+			C.Py_DecRef(list)
+			return nil
+		}
+
+		// This "steals" the ref to value so we don't need to DecRef
+		C.PyList_Append(list, value)
+	}
+
+	return list
+}
+
+func starlarkSetToPython(x starlark.Set) *C.PyObject {
+	set := C.PySet_New(nil)
+	iter := x.Iterate()
+	defer iter.Done()
+
+	var elem starlark.Value
+	for i := 0; iter.Next(&elem); i++ {
+		value := starlarkToPython(elem)
+		defer C.Py_DecRef(value)
+
+		if value == nil {
+			C.Py_DecRef(set)
+			return nil
+		}
+
+		// This does not steal references
+		C.PySet_Add(set, value)
+	}
+
+	return set
+}
+
+func starlarkBytesToPython(x starlark.Bytes) *C.PyObject {
+	cstr := C.CString(string(x))
+	defer C.free(unsafe.Pointer(cstr))
+	return C.PyBytes_FromStringAndSize(cstr, C.Py_ssize_t(x.Len()))
+}
+
+func starlarkToPython(x starlark.Value) *C.PyObject {
+	switch x := x.(type) {
+	case starlark.NoneType:
+		return C.CgoPyNone()
+	case starlark.Bool:
+		if x {
+			return C.CgoPyNewRef(C.Py_True)
+		} else {
+			return C.CgoPyNewRef(C.Py_False)
+		}
+	case starlark.Int:
+		return starlarkIntToPython(x)
+	case starlark.Float:
+		return C.PyFloat_FromDouble(C.double(float64(x)))
+	case starlark.String:
+		return starlarkStringToPython(x)
+	case starlark.Bytes:
+		return starlarkBytesToPython(x)
+	case *starlark.Set:
+		return starlarkSetToPython(*x)
+	case starlark.IterableMapping:
+		return starlarkDictToPython(x)
+	case starlark.Tuple:
+		return starlarkTupleToPython(x)
+	case starlark.Iterable:
+		return starlarkListToPython(x)
+	}
+
+	if C.PyErr_Occurred() == nil {
+		errmsg := C.CString(fmt.Sprintf("Don't know how to convert %s to Python value", reflect.TypeOf(x).String()))
+		defer C.free(unsafe.Pointer(errmsg))
+		C.PyErr_SetString(C.ConversionError, errmsg)
+	}
+
+	return nil
 }
 
 //export StarlarkGo_new
@@ -157,10 +320,13 @@ func StarlarkGo_eval(self *C.StarlarkGo, args *C.PyObject, kwargs *C.PyObject) *
 		return nil
 	}
 
-	cstr := C.CString(result.String())
-	defer C.free(unsafe.Pointer(cstr))
-
-	return C.CgoPyBuildOneValue(C.buildStr, unsafe.Pointer(cstr))
+	if parse == 0 {
+		cstr := C.CString(result.String())
+		defer C.free(unsafe.Pointer(cstr))
+		return C.CgoPyBuildOneValue(C.buildStr, unsafe.Pointer(cstr))
+	} else {
+		return starlarkToPython(result)
+	}
 }
 
 //export StarlarkGo_exec

--- a/starlark.h
+++ b/starlark.h
@@ -33,6 +33,8 @@ PyObject *CgoPyBuildOneValue(const char *fmt, const void *src);
 
 PyObject *CgoPyNone();
 
+PyObject *CgoPyNewRef(PyObject *obj);
+
 int CgoParseEvalArgs(PyObject *args, PyObject *kwargs, char **expr,
                      char **filename, unsigned int *parse);
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -16,6 +16,11 @@ def test_parse_int():
     assert isinstance(x, str)
     assert x == "7"
 
+    # too big to fit in 64 bits
+    x = s.eval("10000000000000000000")
+    assert isinstance(x, int)
+    assert x == 10000000000000000000
+
 
 def test_parse_float():
     s = Starlark()
@@ -110,3 +115,48 @@ def test_parse_dict():
     assert isinstance(x, str)
     assert x.startswith("{")
     assert x.endswith("}")
+
+
+def test_parse_set():
+    s = Starlark()
+
+    x = s.eval("set((1, 2, 3))")
+    assert isinstance(x, set)
+    assert x == set((1, 2, 3))
+
+    x = s.eval("set((1, 2, 3))", parse=True)
+    assert isinstance(x, set)
+    assert x == set((1, 2, 3))
+
+    x = s.eval("set((1, 2, 3))", parse=False)
+    assert isinstance(x, str)
+
+
+def test_parse_bytes():
+    s = Starlark()
+
+    x = s.eval("b'dead0000beef'")
+    assert isinstance(x, bytes)
+    assert x == b"dead0000beef"
+
+    x = s.eval("b'dead0000beef'", parse=True)
+    assert isinstance(x, bytes)
+    assert x == b"dead0000beef"
+
+    x = s.eval("b'dead0000beef'", parse=False)
+    assert isinstance(x, str)
+
+
+def test_tuple():
+    s = Starlark()
+
+    x = s.eval("(13, 37)")
+    assert isinstance(x, tuple)
+    assert x == (13, 37)
+
+    x = s.eval("(13, 37)", parse=True)
+    assert isinstance(x, tuple)
+    assert x == (13, 37)
+
+    x = s.eval("(13, 37)", parse=False)
+    assert isinstance(x, str)


### PR DESCRIPTION
Instead of dumping the value out to a string and then reparsing the
whole thing, construct Python values using the C API and return them
directly.