### PR TITLE
Move most things from setup.py to setup.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .tox
 core
 wheelhouse
+src/pystarlark/scmversion.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
+[build-system]
+requires = [
+  "setuptools >= 40.6.0",
+  "wheel",
+  "setuptools_scm[toml]>=3.4",
+  "setuptools-golang>=2.7",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"
+write_to = "src/pystarlark/scmversion.py"
+
 [tool.isort]
 profile = "black"
 lines_between_types = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,45 @@
+[metadata]
+name = pystarlark
+description = Python bindings for the Go implementation of Starlark
+long_description = file:README.md
+long_description_content_type = text/markdown
+author = Kevin Chung
+author_email = kchung@nyu.edu
+url = https://github.com/ColdHeat/pystarlark
+keywords = starlark
+license = Apache License 2.0
+license_file = LICENSE
+project_urls =
+  Bug Tracker = https://github.com/ColdHeat/pystarlark/issues
+  Source Code = https://github.com/ColdHeat/pystarlark
+classifiers =
+  Development Status :: 4 - Beta
+  Intended Audience :: Developers
+  License :: OSI Approved :: Apache Software License
+  Programming Language :: Python :: 3 :: Only
+  Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
+
+[options]
+packages = find:
+package_dir =
+  = src
+include_package_data = True
+python_requires = >= 3.7
+setup_requires =
+  setuptools_scm[toml] >= 3.4
+  setuptools-golang >= 2.7
+
+[options.packages.find]
+where=src
+
+[options.package_data]
+pystarlark =
+  *.pyi
+  py.typed
+
 [tox:tox]
 envlist = py37, py38, py39, py310
 

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,8 @@
-import re
+from setuptools import Extension, setup
 
-import setuptools
+# I would only use setup.cfg but it can't compile extensions, so here we are.
 
-with open("src/pystarlark/__init__.py", "r", encoding="utf8") as f:
-    version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
-
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-setuptools.setup(
-    name="pystarlark",
-    version=version,
-    author="Kevin Chung",
-    author_email="kchung@nyu.edu",
-    description="Python bindings for Starlark in Go",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/ColdHeat/pystarlark",
-    package_dir={"": "src"},
-    packages=setuptools.find_packages("src"),
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-    python_requires=">=3.7",
-    # I'm not sure what this value is supposed to be
+setup(
     build_golang={"root": "github.com/caketop/pystarlark"},
-    package_data={"pystarlark": ["*.pyi", "py.typed"]},
-    ext_modules=[setuptools.Extension("pystarlark/starlark_go", ["starlark.go"])],
-    setup_requires=["setuptools-golang==2.7.0"],
+    ext_modules=[Extension("pystarlark/starlark_go", ["starlark.go"])],
 )


### PR DESCRIPTION
Also, introduce setuptools_scm and extend pyproject.toml so that we're PEP 518 compliant.