### PR TITLE
Start threads on-demand

### DIFF
--- a/starlark.h
+++ b/starlark.h
@@ -6,7 +6,7 @@
 
 /* Starlark object */
 typedef struct Starlark {
-  PyObject_HEAD unsigned long starlark_thread;
+  PyObject_HEAD unsigned long state_id;
 } Starlark;
 
 /* Helpers for Cgo, which can't handle varargs or macros */


### PR DESCRIPTION
Instead of persisting one thread per Python Starlark object, only
persist the globals, and spin up a new thread for each call to exec
or eval. This will allow multiple python threads to call eval on the
same Starlark object and allow all evaluations to occur in parallel.

Also, make sure each object has a unique ID and sprinkle some mutexes
around to prevent that one really weird bug report from the future.