### PR TITLE
Don't set unspecified in configure_starlark

### DIFF
--- a/starlark.c
+++ b/starlark.c
@@ -1,9 +1,8 @@
 #include "starlark.h"
 
 /* Declarations for object methods written in Go */
-void ConfigureStarlark(unsigned int allowSet, unsigned int allowGlobalReassign,
-                       unsigned int allowRecursion);
-
+void ConfigureStarlark(int allowSet, int allowGlobalReassign,
+                       int allowRecursion);
 Starlark *Starlark_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 void Starlark_dealloc(Starlark *self);
 PyObject *Starlark_eval(Starlark *self, PyObject *args);
@@ -22,7 +21,8 @@ static char *configure_keywords[] = {"allow_set", "allow_global_reassign",
                                      "allow_recursion", NULL};
 
 PyObject *configure_starlark(PyObject *self, PyObject *args, PyObject *kwargs) {
-  unsigned int allow_set = 0, allow_global_reassign = 0, allow_recursion = 0;
+  /* ConfigureStarlark interprets -1 as "unspecified" */
+  int allow_set = -1, allow_global_reassign = -1, allow_recursion = -1;
 
   if (PyArg_ParseTupleAndKeywords(args, kwargs, "|$ppp", configure_keywords,
                                   &allow_set, &allow_global_reassign,

--- a/starlark.go
+++ b/starlark.go
@@ -40,23 +40,27 @@ func init() {
 }
 
 //export ConfigureStarlark
-func ConfigureStarlark(allowSet C.uint, allowGlobalReassign C.uint, allowRecursion C.uint) {
-	if allowSet > 0 {
-		resolve.AllowSet = true
-	} else {
+func ConfigureStarlark(allowSet C.int, allowGlobalReassign C.int, allowRecursion C.int) {
+	// Ignore input values other than 0 or 1 and leave current value in place
+	switch allowSet {
+	case 0:
 		resolve.AllowSet = false
+	case 1:
+		resolve.AllowSet = true
 	}
 
-	if allowGlobalReassign > 0 {
-		resolve.AllowGlobalReassign = true
-	} else {
+	switch allowGlobalReassign {
+	case 0:
 		resolve.AllowGlobalReassign = false
+	case 1:
+		resolve.AllowGlobalReassign = true
 	}
 
-	if allowRecursion > 0 {
-		resolve.AllowRecursion = true
-	} else {
+	switch allowRecursion {
+	case 0:
 		resolve.AllowRecursion = false
+	case 1:
+		resolve.AllowRecursion = true
 	}
 }
 


### PR DESCRIPTION
Make configure_starlark smart enough to distinguish between "False" and
"not specified", and avoid resetting things to False when they weren't
specified.

Also add another test to exercise recursion.