### PR TITLE
Tweak clang-format to look like black

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_IMAGE=quay.io/pypa/manylinux_2_24_x86_64
 ARG GO_URL=https://go.dev/dl/go1.18.1.linux-amd64.tar.gz
+ARG CLANG_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
 ARG SHELLCHECK_URL=https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz
 ARG MCFLY_URL=https://github.com/cantino/mcfly/releases/download/v0.6.0/mcfly-v0.6.0-x86_64-unknown-linux-musl.tar.gz
 
@@ -13,7 +14,7 @@ FROM ${BASE_IMAGE} AS packages
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-  build-essential clang-format gdb less libffi-dev valgrind \
+  build-essential gdb less libffi-dev valgrind \
   curl ca-certificates gnupg2 tar g++ gcc libc6-dev make pkg-config
 
 RUN curl -sS https://starship.rs/install.sh | sh -s -- -y
@@ -59,7 +60,7 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 
 FROM builder AS misc
 
-ARG SHELLCHECK_URL MCFLY_URL USERNAME
+ARG SHELLCHECK_URL MCFLY_URL CLANG_URL USERNAME
 
 ADD --chown=${USERNAME} ${SHELLCHECK_URL} /usr/src/shellcheck.tar.xz
 
@@ -68,6 +69,10 @@ RUN mkdir /tmp/shellcheck && tar -C /tmp/shellcheck --strip-components=1 -xvf /u
 ADD --chown=${USERNAME} ${MCFLY_URL} /usr/src/mcfly.tar.gz
 
 RUN mkdir /tmp/mcfly && tar -C /tmp/mcfly -xvf /usr/src/mcfly.tar.gz
+
+ADD --chown=${USERNAME} ${CLANG_URL} /usr/src/clang.tar.xz
+
+RUN mkdir /tmp/clang && tar -C /tmp/clang --strip-components=1 -xvf /usr/src/clang.tar.xz
 
 
 FROM builder AS devcontainer
@@ -78,10 +83,11 @@ RUN echo "set auto-load safe-path /" > /home/${USERNAME}/.gdbinit
 
 COPY --from=go_tools /home/${USERNAME}/go/bin/ /home/${USERNAME}/go/bin
 
-RUN python3.10 -m pip install --user black isort pytest tox
+RUN python3.10 -m pip install --user black isort memray pytest tox
 
 COPY --from=misc /tmp/shellcheck/shellcheck /home/${USERNAME}/.local/bin/shellcheck
 COPY --from=misc /tmp/mcfly/mcfly /home/${USERNAME}/.local/bin/mcfly
+COPY --from=misc /tmp/clang/bin/clang-format /home/${USERNAME}/.local/bin/clang-format
 
 RUN echo 'eval "$(mcfly init bash)"' >> ~/.bashrc && touch ~/.bash_history
 RUN echo 'eval "$(starship init bash)"' >> ~/.bashrc

--- a/starlark.c
+++ b/starlark.c
@@ -1,8 +1,9 @@
 #include "starlark.h"
 
 /* Declarations for object methods written in Go */
-void ConfigureStarlark(int allowSet, int allowGlobalReassign,
-                       int allowRecursion);
+void ConfigureStarlark(
+    int allowSet, int allowGlobalReassign, int allowRecursion
+);
 Starlark *Starlark_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 void Starlark_dealloc(Starlark *self);
 PyObject *Starlark_eval(Starlark *self, PyObject *args);
@@ -21,16 +22,24 @@ PyObject *ResolveErrorItem;
 PyObject *ConversionError;
 
 /* Wrapper for setting Starlark configuration options */
-static char *configure_keywords[] = {"allow_set", "allow_global_reassign",
-                                     "allow_recursion", NULL};
+static char *configure_keywords[] = {
+    "allow_set", "allow_global_reassign", "allow_recursion", NULL /* Sentinel */
+};
 
-PyObject *configure_starlark(PyObject *self, PyObject *args, PyObject *kwargs) {
+PyObject *configure_starlark(PyObject *self, PyObject *args, PyObject *kwargs)
+{
   /* ConfigureStarlark interprets -1 as "unspecified" */
   int allow_set = -1, allow_global_reassign = -1, allow_recursion = -1;
 
-  if (PyArg_ParseTupleAndKeywords(args, kwargs, "|$ppp", configure_keywords,
-                                  &allow_set, &allow_global_reassign,
-                                  &allow_recursion) == NULL) {
+  if (PyArg_ParseTupleAndKeywords(
+          args,
+          kwargs,
+          "|$ppp",
+          configure_keywords,
+          &allow_set,
+          &allow_global_reassign,
+          &allow_recursion
+      ) == 0) {
     return NULL;
   }
 
@@ -40,30 +49,40 @@ PyObject *configure_starlark(PyObject *self, PyObject *args, PyObject *kwargs) {
 
 /* Container for module methods */
 static PyMethodDef module_methods[] = {
-    {"configure_starlark", (PyCFunction)configure_starlark,
-     METH_VARARGS | METH_KEYWORDS, "Configure the starlark interpreter"},
-    {NULL}};
+    {"configure_starlark",
+     (PyCFunction)configure_starlark,
+     METH_VARARGS | METH_KEYWORDS,
+     "Configure the starlark interpreter"},
+    {NULL} /* Sentinel */
+};
 
 /* Container for object methods */
 static PyMethodDef StarlarkGo_methods[] = {
-    {"eval", (PyCFunction)Starlark_eval, METH_VARARGS | METH_KEYWORDS,
+    {"eval",
+     (PyCFunction)Starlark_eval,
+     METH_VARARGS | METH_KEYWORDS,
      "Evaluate a Starlark expression"},
-    {"exec", (PyCFunction)Starlark_exec, METH_VARARGS | METH_KEYWORDS,
+    {"exec",
+     (PyCFunction)Starlark_exec,
+     METH_VARARGS | METH_KEYWORDS,
      "Execute Starlark code, modifying the global state"},
     {"keys", (PyCFunction)Starlark_keys, METH_NOARGS, "TODO"},
     {NULL} /* Sentinel */
 };
 
 /* Container for object mapping methods */
-static PyMappingMethods StarlarkGo_mapping = {.mp_length = Starlark_mp_length,
-                                              .mp_subscript =
-                                                  Starlark_mp_subscript,
-                                              .mp_ass_subscript = NULL};
+static PyMappingMethods StarlarkGo_mapping = {
+    .mp_length = Starlark_mp_length,
+    .mp_subscript = Starlark_mp_subscript,
+    .mp_ass_subscript = NULL,
+};
 
 /* Python type for object */
 static PyTypeObject StarlarkType = {
-    PyVarObject_HEAD_INIT(NULL, 0) // this confuses clang-format
-        .tp_name = "pystarlark.starlark_go.Starlark",
+    // clang-format off
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "pystarlark.starlark_go.Starlark",
+    // clang-format on
     .tp_doc = "Starlark interpreter",
     .tp_basicsize = sizeof(Starlark),
     .tp_itemsize = 0,
@@ -76,68 +95,94 @@ static PyTypeObject StarlarkType = {
 };
 
 /* Module */
-static PyModuleDef pystarlark_lib = {PyModuleDef_HEAD_INIT,
-                                     .m_name = "pystarlark.starlark_go",
-                                     .m_doc = "Interface to starlark-go",
-                                     .m_size = -1, .m_methods = module_methods};
+static PyModuleDef pystarlark_lib = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "pystarlark.starlark_go",
+    .m_doc = "Interface to starlark-go",
+    .m_size = -1,
+    .m_methods = module_methods,
+};
 
 /* Argument names for our methods */
 static char *eval_keywords[] = {"expr", "filename", "convert", NULL};
 static char *exec_keywords[] = {"defs", "filename", NULL};
 
 /* Helpers to allocate and free our object */
-Starlark *starlarkAlloc(PyTypeObject *type) {
+Starlark *starlarkAlloc(PyTypeObject *type)
+{
   /* Necessary because Cgo can't do function pointers */
   return (Starlark *)type->tp_alloc(type, 0);
 }
 
-void starlarkFree(Starlark *self) {
+void starlarkFree(Starlark *self)
+{
   /* Necessary because Cgo can't do function pointers */
   Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 /* Helpers to parse method arguments */
-int parseEvalArgs(PyObject *args, PyObject *kwargs, char **expr,
-                  char **filename, unsigned int *convert) {
+int parseEvalArgs(
+    PyObject *args,
+    PyObject *kwargs,
+    char **expr,
+    char **filename,
+    unsigned int *convert
+)
+{
   /* Necessary because Cgo can't do varargs */
   /* One required string, folloed by an optional string and an optional bool */
-  return PyArg_ParseTupleAndKeywords(args, kwargs, "s|$sp", eval_keywords, expr,
-                                     filename, convert);
+  return PyArg_ParseTupleAndKeywords(
+      args, kwargs, "s|$sp", eval_keywords, expr, filename, convert
+  );
 }
 
-int parseExecArgs(PyObject *args, PyObject *kwargs, char **defs,
-                  char **filename) {
+int parseExecArgs(
+    PyObject *args, PyObject *kwargs, char **defs, char **filename
+)
+{
   /* Necessary because Cgo can't do varargs */
   /* One required string, folloed by an optional string */
-  return PyArg_ParseTupleAndKeywords(args, kwargs, "s|$s", exec_keywords, defs,
-                                     filename);
+  return PyArg_ParseTupleAndKeywords(
+      args, kwargs, "s|$s", exec_keywords, defs, filename
+  );
 }
 
 /* Helpers for Cgo to build exception arguments */
-PyObject *makeStarlarkErrorArgs(const char *error_msg, const char *error_type) {
+PyObject *makeStarlarkErrorArgs(const char *error_msg, const char *error_type)
+{
   /* Necessary because Cgo can't do varargs */
   return Py_BuildValue("ss", error_msg, error_type);
 }
 
-PyObject *makeSyntaxErrorArgs(const char *error_msg, const char *error_type,
-                              const char *msg, const char *filename,
-                              const unsigned int line,
-                              const unsigned int column) {
+PyObject *makeSyntaxErrorArgs(
+    const char *error_msg,
+    const char *error_type,
+    const char *msg,
+    const char *filename,
+    const unsigned int line,
+    const unsigned int column
+)
+{
   /* Necessary because Cgo can't do varargs */
   /* Four strings and two unsigned integers */
-  return Py_BuildValue("ssssII", error_msg, error_type, msg, filename, line,
-                       column);
+  return Py_BuildValue(
+      "ssssII", error_msg, error_type, msg, filename, line, column
+  );
 }
 
-PyObject *makeEvalErrorArgs(const char *error_msg, const char *error_type,
-                            const char *backtrace) {
+PyObject *makeEvalErrorArgs(
+    const char *error_msg, const char *error_type, const char *backtrace
+)
+{
   /* Necessary because Cgo can't do varargs */
   /* Three strings */
   return Py_BuildValue("sss", error_msg, error_type, backtrace);
 }
 
-PyObject *makeResolveErrorItem(const char *msg, const unsigned int line,
-                               const unsigned int column) {
+PyObject *makeResolveErrorItem(
+    const char *msg, const unsigned int line, const unsigned int column
+)
+{
   /* Necessary because Cgo can't do varargs */
   /* A string and two unsigned integers */
   PyObject *args = Py_BuildValue("sII", msg, line, column);
@@ -146,20 +191,24 @@ PyObject *makeResolveErrorItem(const char *msg, const unsigned int line,
   return obj;
 }
 
-PyObject *makeResolveErrorArgs(const char *error_msg, const char *error_type,
-                               PyObject *errors) {
+PyObject *makeResolveErrorArgs(
+    const char *error_msg, const char *error_type, PyObject *errors
+)
+{
   /* Necessary because Cgo can't do varargs */
   /* Two strings and a Python object */
   return Py_BuildValue("ssO", error_msg, error_type, errors);
 }
 
 /* Other assorted helpers for Cgo */
-PyObject *cgoPy_BuildString(const char *src) {
+PyObject *cgoPy_BuildString(const char *src)
+{
   /* Necessary because Cgo can't do varargs */
   return Py_BuildValue("s", src);
 }
 
-PyObject *cgoPy_NewRef(PyObject *obj) {
+PyObject *cgoPy_NewRef(PyObject *obj)
+{
   /* Necessary because Cgo can't do macros and Py_NewRef is part of
    * Python's "stable API" but only since 3.10
    */
@@ -168,53 +217,47 @@ PyObject *cgoPy_NewRef(PyObject *obj) {
 }
 
 /* Helper to fetch exception classes */
-static PyObject *get_exception_class(PyObject *errors, const char *name) {
+static PyObject *get_exception_class(PyObject *errors, const char *name)
+{
   PyObject *retval = PyObject_GetAttrString(errors, name);
 
   if (retval == NULL)
-    PyErr_Format(PyExc_RuntimeError, "pystarlark.errors.%s is not defined",
-                 name);
+    PyErr_Format(
+        PyExc_RuntimeError, "pystarlark.errors.%s is not defined", name
+    );
 
   return retval;
 }
 
 /* Module initialization */
-PyMODINIT_FUNC PyInit_starlark_go(void) {
+PyMODINIT_FUNC PyInit_starlark_go(void)
+{
   PyObject *errors = PyImport_ImportModule("pystarlark.errors");
-  if (errors == NULL)
-    return NULL;
+  if (errors == NULL) return NULL;
 
   StarlarkError = get_exception_class(errors, "StarlarkError");
-  if (StarlarkError == NULL)
-    return NULL;
+  if (StarlarkError == NULL) return NULL;
 
   SyntaxError = get_exception_class(errors, "SyntaxError");
-  if (SyntaxError == NULL)
-    return NULL;
+  if (SyntaxError == NULL) return NULL;
 
   EvalError = get_exception_class(errors, "EvalError");
-  if (EvalError == NULL)
-    return NULL;
+  if (EvalError == NULL) return NULL;
 
   ResolveError = get_exception_class(errors, "ResolveError");
-  if (ResolveError == NULL)
-    return NULL;
+  if (ResolveError == NULL) return NULL;
 
   ResolveErrorItem = get_exception_class(errors, "ResolveErrorItem");
-  if (ResolveErrorItem == NULL)
-    return NULL;
+  if (ResolveErrorItem == NULL) return NULL;
 
   ConversionError = get_exception_class(errors, "ConversionError");
-  if (ConversionError == NULL)
-    return NULL;
+  if (ConversionError == NULL) return NULL;
 
   PyObject *m;
-  if (PyType_Ready(&StarlarkType) < 0)
-    return NULL;
+  if (PyType_Ready(&StarlarkType) < 0) return NULL;
 
   m = PyModule_Create(&pystarlark_lib);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
 
   Py_INCREF(&StarlarkType);
   if (PyModule_AddObject(m, "Starlark", (PyObject *)&StarlarkType) < 0) {

--- a/starlark.h
+++ b/starlark.h
@@ -1,6 +1,7 @@
 #ifndef PYTHON_STARLARK_GO_H
 #define PYTHON_STARLARK_GO_H
 
+#include <stdlib.h>
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
@@ -14,27 +15,40 @@ Starlark *starlarkAlloc(PyTypeObject *type);
 
 void starlarkFree(Starlark *self);
 
-int parseEvalArgs(PyObject *args, PyObject *kwargs, char **expr,
-                  char **filename, unsigned int *convert);
+int parseEvalArgs(
+    PyObject *args,
+    PyObject *kwargs,
+    char **expr,
+    char **filename,
+    unsigned int *convert
+);
 
-int parseExecArgs(PyObject *args, PyObject *kwargs, char **defs,
-                  char **filename);
+int parseExecArgs(
+    PyObject *args, PyObject *kwargs, char **defs, char **filename
+);
 
 PyObject *makeStarlarkErrorArgs(const char *error_msg, const char *error_type);
 
-PyObject *makeSyntaxErrorArgs(const char *error_msg, const char *error_type,
-                              const char *msg, const char *filename,
-                              const unsigned int line,
-                              const unsigned int column);
+PyObject *makeSyntaxErrorArgs(
+    const char *error_msg,
+    const char *error_type,
+    const char *msg,
+    const char *filename,
+    const unsigned int line,
+    const unsigned int column
+);
 
-PyObject *makeEvalErrorArgs(const char *error_msg, const char *error_type,
-                            const char *backtrace);
+PyObject *makeEvalErrorArgs(
+    const char *error_msg, const char *error_type, const char *backtrace
+);
 
-PyObject *makeResolveErrorItem(const char *msg, const unsigned int line,
-                               const unsigned int column);
+PyObject *makeResolveErrorItem(
+    const char *msg, const unsigned int line, const unsigned int column
+);
 
-PyObject *makeResolveErrorArgs(const char *error_msg, const char *error_type,
-                               PyObject *errors);
+PyObject *makeResolveErrorArgs(
+    const char *error_msg, const char *error_type, PyObject *errors
+);
 
 PyObject *cgoPy_BuildString(const char *src);
 


### PR DESCRIPTION
I didn't love the standard LLVM style, so here's a tweak to make it look more like Black formats Python.