### PR TITLE
CI: Build wheels with right version & test them

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -15,7 +15,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,7 @@ write_to = "src/pystarlark/scmversion.py"
 [tool.isort]
 profile = "black"
 lines_between_types = 1
+
+[tool.cibuildwheel]
+test-requires = "pytest"
+test-command = "pytest {project}/tests"


### PR DESCRIPTION
- Checkout full repo history so setuptools_scm can work correctly
- Induce cibuildwheel to run the tests after building the wheel