### PR TITLE
Allow redirecting Starlark's print()

### DIFF
--- a/python_print.go
+++ b/python_print.go
@@ -1,0 +1,108 @@
+package main
+
+/*
+#include "starlark.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+//export Starlark_get_print
+func Starlark_get_print(self *C.Starlark, closure *C.void) *C.PyObject {
+	state := rlockSelf(self)
+	if state == nil {
+		return nil
+	}
+	defer state.Mutex.RUnlock()
+
+	if state.Print == nil {
+		return C.cgoPy_NewRef(C.Py_None)
+	}
+
+	return C.cgoPy_NewRef(state.Print)
+}
+
+//export Starlark_set_print
+func Starlark_set_print(self *C.Starlark, value *C.PyObject, closure *C.void) C.int {
+	if value == C.Py_None {
+		value = nil
+	}
+
+	if value != nil {
+		if C.PyCallable_Check(value) != 1 {
+			errmsg := C.CString(fmt.Sprintf("%s is not callable", C.GoString(value.ob_type.tp_name)))
+			defer C.free(unsafe.Pointer(errmsg))
+			C.PyErr_SetString(C.PyExc_TypeError, errmsg)
+			return -1
+		}
+	}
+
+	state := lockSelf(self)
+	if state == nil {
+		return -1
+	}
+	defer state.Mutex.Unlock()
+
+	state.Print = C.cgoPy_NewRef(value)
+	return 0
+}
+
+func pythonPrint(self *C.Starlark, print *C.PyObject) *C.PyObject {
+	if print == nil {
+		state := rlockSelf(self)
+		if state == nil {
+			return nil
+		}
+		defer state.Mutex.RUnlock()
+		print = state.Print
+	}
+
+	if print == nil {
+		print = pythonBuiltinPrint()
+	}
+
+	if print == nil {
+		errmsg := C.CString("Couldn't find print()?")
+		defer C.free(unsafe.Pointer(errmsg))
+		C.PyErr_SetString(C.PyExc_TypeError, errmsg)
+		return nil
+	}
+
+	if C.PyCallable_Check(print) != 1 {
+		errmsg := C.CString(fmt.Sprintf("%s is not callable", C.GoString(print.ob_type.tp_name)))
+		defer C.free(unsafe.Pointer(errmsg))
+		C.PyErr_SetString(C.PyExc_TypeError, errmsg)
+		return nil
+	}
+
+	return print
+}
+
+func pythonBuiltinPrint() *C.PyObject {
+	builtins := C.PyEval_GetBuiltins()
+	if builtins == nil {
+		return nil
+	}
+
+	cstr := C.CString("print")
+	defer C.free(unsafe.Pointer(cstr))
+	return C.PyDict_GetItemString(builtins, cstr)
+}
+
+func callPythonPrint(print *C.PyObject, msg string) {
+	cmsg := C.CString(msg)
+	defer C.free(unsafe.Pointer(cmsg))
+
+	pymsg := C.cgoPy_BuildString(cmsg)
+	args := C.PyTuple_New(1)
+	defer C.Py_DecRef(args)
+
+	if C.PyTuple_SetItem(args, 0, pymsg) == 0 {
+		C.PyObject_CallObject(print, args)
+	} else {
+		C.Py_DecRef(pymsg)
+	}
+}

--- a/scripts/pytest-valgrind.supp
+++ b/scripts/pytest-valgrind.supp
@@ -8,12 +8,43 @@
 {
    go-runtime-adjustpointer
    Memcheck:Cond
-   fun:runtime.adjustpointer
+   fun:runtime.adjustpointer*
    obj:*
 }
 
 {
-   go-runtime-asyncPreempt
+   go-runtime-adjustpointer-Addr8
+   Memcheck:Addr8
+   fun:runtime.adjustpointer*
+   obj:*
+}
+
+{
+   go-runtime-asyncPreempt-Addr8
    Memcheck:Addr8
    fun:runtime.asyncPreempt.abi0
+}
+
+{
+   go-runtime-asyncPreempt-Addr16
+   Memcheck:Addr16
+   fun:runtime.asyncPreempt.abi0
+}
+
+{
+   starlark-addr4
+   Memcheck:Addr4
+   fun:go.starlark.net/*
+}
+
+{
+   starlark-addr8
+   Memcheck:Addr8
+   fun:go.starlark.net/*
+}
+
+{
+   starlark-addr32
+   Memcheck:Addr32
+   fun:go.starlark.net/*
 }

--- a/src/pystarlark/starlark_go.pyi
+++ b/src/pystarlark/starlark_go.pyi
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, Optional
+from typing import Any, Callable, List, Mapping, Optional
 
 def configure_starlark(
     *,
@@ -8,12 +8,34 @@ def configure_starlark(
 ) -> None: ...
 
 class Starlark:
-    def __init__(self, *, globals: Optional[Mapping[str, Any]] = ...) -> None: ...
+    def __init__(
+        self,
+        *,
+        globals: Optional[Mapping[str, Any]] = ...,
+        print: Callable[[str], Any] = ...,
+    ) -> None: ...
     def eval(
-        self, expr: str, *, filename: Optional[str] = ..., convert: Optional[bool] = ...
+        self,
+        expr: str,
+        *,
+        filename: Optional[str] = ...,
+        convert: Optional[bool] = ...,
+        print: Callable[[str], Any] = ...,
     ) -> Any: ...
-    def exec(self, defs: str, *, filename: Optional[str] = ...) -> None: ...
+    def exec(
+        self,
+        defs: str,
+        *,
+        filename: Optional[str] = ...,
+        print: Callable[[str], Any] = ...,
+    ) -> None: ...
     def globals(self) -> List[str]: ...
     def get(self, name: str, default_value: Optional[Any] = ...) -> None: ...
     def set(self, **kwargs: Any) -> None: ...
     def pop(self, name: str, default_value: Optional[Any] = ...) -> Any: ...
+    @property
+    def print(self) -> Optional[Callable[[str], Any]]: ...
+    @print.setter
+    def print(
+        self, value: Optional[Callable[[str], Any]]
+    ) -> Optional[Callable[[str], Any]]: ...

--- a/starlark.h
+++ b/starlark.h
@@ -16,17 +16,22 @@ Starlark *starlarkAlloc(PyTypeObject *type);
 
 void starlarkFree(Starlark *self);
 
-int parseInitArgs(PyObject *args, PyObject *kwargs, PyObject **globals);
+int parseInitArgs(
+    PyObject *args, PyObject *kwargs, PyObject **globals, PyObject **print
+);
 
 int parseEvalArgs(
     PyObject *args,
     PyObject *kwargs,
     char **expr,
     char **filename,
-    unsigned int *convert
+    unsigned int *convert,
+    PyObject **print
 );
 
-int parseExecArgs(PyObject *args, PyObject *kwargs, char **defs, char **filename);
+int parseExecArgs(
+    PyObject *args, PyObject *kwargs, char **defs, char **filename, PyObject **print
+);
 
 int parseGetGlobalArgs(
     PyObject *args, PyObject *kwargs, char **name, PyObject **default_value

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,0 +1,65 @@
+from io import StringIO
+
+import pytest
+
+from pystarlark import Starlark
+
+
+def test_print_eval(capsys: pytest.CaptureFixture[str]):
+    s = Starlark()
+    s.eval('print("hello")')
+
+    captured = capsys.readouterr()
+    assert captured.out == "hello\n"
+
+
+def test_print_exec(capsys: pytest.CaptureFixture[str]):
+    s = Starlark()
+    s.exec('print("hello")')
+
+    captured = capsys.readouterr()
+    assert captured.out == "hello\n"
+
+
+def test_more_eval():
+    a = StringIO()
+    b = StringIO()
+
+    s = Starlark(print=lambda x: a.write(x + "\n"))
+    s.eval('print("hello")')
+
+    assert a.getvalue() == "hello\n"
+
+    s.eval('print("hello")', print=lambda x: b.write(x + "\n"))
+
+    assert a.getvalue() == "hello\n"
+    assert b.getvalue() == "hello\n"
+
+    s.print = lambda x: b.write(x + "\n")
+
+    s.eval('print("goodbye")')
+
+    assert a.getvalue() == "hello\n"
+    assert b.getvalue() == "hello\ngoodbye\n"
+
+
+def test_more_exec():
+    a = StringIO()
+    b = StringIO()
+
+    s = Starlark(print=lambda x: a.write(x + "\n"))
+    s.exec('print("hello")')
+
+    assert a.getvalue() == "hello\n"
+
+    s.exec('print("hello")', print=lambda x: b.write(x + "\n"))
+
+    assert a.getvalue() == "hello\n"
+    assert b.getvalue() == "hello\n"
+
+    s.print = lambda x: b.write(x + "\n")
+
+    s.exec('print("goodbye")')
+
+    assert a.getvalue() == "hello\n"
+    assert b.getvalue() == "hello\ngoodbye\n"


### PR DESCRIPTION
Starlark's print function can now be redirected, by specifying `print=`
to the constructor, by specifying `print=` to `eval()` or `exec()`, or
by setting `.print` on a `Starlark` object. In all three cases, the
value of `print` should be a callable that accepts one string and does
whatever you want with it.

Closes https://github.com/caketop/pystarlark/issues/13