### PR TITLE
Tweaks: C line length = 88, memray during tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,3 +11,5 @@ BinPackParameters: false
 AlignAfterOpenBracket: BlockIndent
 AllowAllArgumentsOnNextLine: true
 Cpp11BracedListStyle: true
+ColumnLimit: 88
+PenaltyReturnTypeOnItsOwnLine: 1000

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,15 @@ python =
     3.10: py310
 
 [testenv]
+deps =
+  -r development.txt
+  pytest-memray
+commands = pytest -v --memray
+
+[testenv:py37]
 deps = -r development.txt
 commands = pytest -v
 
 [flake8]
-max-line-length = 180
+max-line-length = 88
 extend-ignore = E203, W503


### PR DESCRIPTION
- Set the clang-format line length to 88, to match black
- Use memray to generate allocation information during tests