### PR TITLE
Schedule starlark-go update on Saturdays

### DIFF
--- a/.github/workflows/update-starlark.yml
+++ b/.github/workflows/update-starlark.yml
@@ -1,7 +1,7 @@
 name: Update starlark-go
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '59 14 * * 6' 
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Running hourly was driving me mad as it's currently failing [^mad] and absolutely does not need to be updated that often. I wouldn't be surprised if I even scale it back to monthly.

[^mad]: Falls apart; someday (but not every morning) - https://en.wikipedia.org/wiki/14:59