### PR TITLE
Use new wheel upload keys to download before uploading to GHR and PyPi

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
+          name: sdist
           path: dist/*.tar.gz
 
   # Build binary distributions for PyPI
@@ -104,8 +105,14 @@ jobs:
 
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: artifact
+          name: sdist
           path: dist
+
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
 
       - name: "✏️ Generate release changelog"
         id: changelog
@@ -133,8 +140,14 @@ jobs:
     steps:
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: artifact
+          name: sdist
           path: dist
+
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
@@ -153,8 +166,14 @@ jobs:
     steps:
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: artifact
+          name: sdist
           path: dist
+
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:


### PR DESCRIPTION
When I provided an upload key for the wheel build in bc4e7e1d50098d6eff2ab9b0178361c61a57a115, I failed to then add a download using this key or the key pattern later on in the build.

Fixes #272 