### PR TITLE
Change release body to use generated changelog file instead of action output

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -124,11 +124,14 @@ jobs:
           prWoLabels: true
           token: ${{ secrets.GITHUB_TOKEN }}
           verbose: true
+          # Have to use a file because using action outputs is broken in 2.4
+          # See https://github.com/janheinrichmerker/action-github-changelog-generator/issues/44
+          output: generated_changelog.md
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
         with:
-          body: ${{ steps.changelog.outputs.changelog }}
+          body_path: generated_changelog.md
           files: dist/**/*
 
   # Test PyPI


### PR DESCRIPTION
https://github.com/caketop/python-starlark-go/releases/tag/v1.0.1rc1 and the release before it both have spurious URL escaped new lines in plain text. I speculate that there's something about how the generated changelog is getting marshaled into the GH release body. 2.4 of the generator changed how action outputs are passed, and [its urlencoding][1] may be unnecessary.

Before this commit, the generated changelog is passed as a string to the GH release body.

I think it would be safer to configure the changelog generator to write a file with output and action-gh-release to read it in via its body_path.

janheinrichmerker/action-github-changelog-generator#44 is also documenting the issue and others have reported that 2.3 doesn't have the problem.. but 2.3 uses ::set-output which IIRC has been disabled. Using a file it is.

[1]: https://github.com/janheinrichmerker/action-github-changelog-generator/blob/e60b5a2bd9fcd88dadf6345ff8327863fb8b490f/entrypoint.sh#L164-L167

Work toward #274