### PR TITLE
Adds new memray dependency libdebuginfod-dev to deps for Python -dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         if: endsWith(matrix.python-version, '-dev')
         env:
           DEBIAN_FRONTEND: noninteractive
-        run: sudo apt-get install --yes --no-install-recommends libunwind-dev liblz4-dev
+        run: sudo apt-get install --yes --no-install-recommends libunwind-dev liblz4-dev libdebuginfod-dev
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This appears to be the missing package.

https://github.com/caketop/python-starlark-go/actions/runs/19605602686/job/56143997615#step:7:517