### PR TITLE
Disable setup-go caching, affecting non-Linux runners

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -69,6 +69,7 @@ jobs:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: 'stable'
+          cache: false
         if: runner.os != 'Linux'
 
       - name: Set up QEMU


### PR DESCRIPTION
Zizmor throws an error when setup-go doesn't have cache:false, but the real problem is when the cache is kept and the artifacts are uploaded. Its check seems not to validate the last part...?

https://docs.zizmor.sh/audits/#cache-poisoning

I think it's simplest to just disable the caching for now and return to a finer-tuned setting later.

Fixes https://github.com/caketop/python-starlark-go/security/code-scanning/60