### PR TITLE
Moves the release text body appending parameter to the correct action

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -128,15 +128,15 @@ jobs:
           # Have to use a file because using action outputs is broken in 2.4
           # See https://github.com/janheinrichmerker/action-github-changelog-generator/issues/44
           output: generated_changelog.md
-          # In case the release already exists because it was manually created,
-          # and the author has written a SMASHINGLY GOOD blurb.
-          append_body: true
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           body_path: generated_changelog.md
           files: dist/**/*
+          # In case the release already exists because it was manually created,
+          # and the author has written a SMASHINGLY GOOD blurb.
+          append_body: true
 
   # Test PyPI
   test_pypi_publish:


### PR DESCRIPTION
The generator takes a base that would have to be retrieved, but this `append_body` is on action-gh-release!